### PR TITLE
FEATURE: Add link to developer/GH info in Admin dropdown

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -153,6 +153,12 @@ export default function AppNavbar({
                   >
                     Manage Jobs
                   </NavDropdown.Item>
+                  <NavDropdown.Item
+                    href="/developer"
+                    data-testid="appnavbar-developer"
+                  >
+                    Developer Info
+                  </NavDropdown.Item>
                 </NavDropdown>
               )}
             </Nav>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -155,7 +155,7 @@ export default function AppNavbar({
                   </NavDropdown.Item>
                   <NavDropdown.Item
                     href="/developer"
-                    data-testid="appnavbar-developer"
+                    data-testid="appnavbar-admin-developer"
                   >
                     Developer Info
                   </NavDropdown.Item>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -154,8 +154,8 @@ export default function AppNavbar({
                     Manage Jobs
                   </NavDropdown.Item>
                   <NavDropdown.Item
-                    href="/admin/developer"
-                    data-testid="appnavbar-admin-developer"
+                    href="/developer"
+                    data-testid="appnavbar-developer"
                   >
                     Developer Info
                   </NavDropdown.Item>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -154,7 +154,7 @@ export default function AppNavbar({
                     Manage Jobs
                   </NavDropdown.Item>
                   <NavDropdown.Item
-                    href="/developer"
+                    href="/admin/developer"
                     data-testid="appnavbar-admin-developer"
                   >
                     Developer Info

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -58,12 +58,7 @@ describe("AppNavbar tests", () => {
     expect(
       screen.getByTestId(/appnavbar-admin-personalschedule/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("appnavbar-admin-jobs"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("appnavbar-admin-developer"),
-    ).toBeInTheDocument();
+    expect(screen.getByTestId("appnavbar-developer")).toBeInTheDocument();
   });
 
   test("renders H2Console and Swagger links correctly", async () => {

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -59,10 +59,10 @@ describe("AppNavbar tests", () => {
       screen.getByTestId(/appnavbar-admin-personalschedule/),
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId(/appnavbar-admin-jobs/),
+      screen.getByTestId("appnavbar-admin-jobs"),
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId(/appnavbar-admin-developer/),
+      screen.getByTestId("appnavbar-admin-developer"),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -62,7 +62,7 @@ describe("AppNavbar tests", () => {
       screen.getByTestId(/appnavbar-admin-jobs/),
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId(/appnavbar-developer/),
+      screen.getByTestId(/appnavbar-admin-developer/),
     ).toBeInTheDocument();
   });
 

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -58,6 +58,7 @@ describe("AppNavbar tests", () => {
     expect(
       screen.getByTestId(/appnavbar-admin-personalschedule/),
     ).toBeInTheDocument();
+    expect(screen.getByTestId("appnavbar-admin-jobs")).toBeInTheDocument();
     expect(screen.getByTestId("appnavbar-developer")).toBeInTheDocument();
   });
 

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -58,6 +58,12 @@ describe("AppNavbar tests", () => {
     expect(
       screen.getByTestId(/appnavbar-admin-personalschedule/),
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(/appnavbar-admin-jobs/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(/appnavbar-developer/),
+    ).toBeInTheDocument();
   });
 
   test("renders H2Console and Swagger links correctly", async () => {


### PR DESCRIPTION
In this PR, we added developer info in admin dropdown in AppNavbar.js and it's test.
http://courses-qa.dokku-06.cs.ucsb.edu
https://courses-qa.dokku-06.cs.ucsb.edu

There is an item in the Admin dropdown called "Developer Info".
<img width="1036" alt="Screen Shot 2024-02-27 at 6 19 35 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-2/assets/124765197/ac561f69-8125-4dad-8e93-20486af3c5a4">

Clicking on this item redirects to [app-link]/developer.
<img width="1364" alt="Screen Shot 2024-02-27 at 6 18 28 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-2/assets/124765197/3de8530f-def9-4e1f-9a78-a2fa4f648350">

Closes #3 