### PR TITLE
BUG: Can't immediately search for graduate courses

### DIFF
--- a/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
+++ b/frontend/src/main/components/BasicCourseSearch/BasicCourseSearchForm.js
@@ -23,7 +23,7 @@ const BasicCourseSearchForm = ({ fetchJSON }) => {
   // Stryker disable all : not sure how to test/mock local storage
   const localSubject = localStorage.getItem("BasicSearch.Subject");
   const localQuarter = localStorage.getItem("BasicSearch.Quarter");
-  const localLevel = localStorage.getItem("BasicSearch.CourseLevel");
+  const localLevel = localStorage.getItem("BasicSearch.Level");
 
   const {
     data: subjects,

--- a/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
+++ b/frontend/src/tests/components/Levels/SingleLevelDropdown.test.js
@@ -102,7 +102,7 @@ describe("SingleLevelDropdown tests", () => {
 
   test("when localstorage has a value, it is passed to useState", async () => {
     const getItemSpy = jest.spyOn(Storage.prototype, "getItem");
-    getItemSpy.mockImplementation(() => "U");
+    getItemSpy.mockImplementation(() => "G");
 
     const setLevelStateSpy = jest.fn();
     useState.mockImplementation((x) => [x, setLevelStateSpy]);
@@ -116,7 +116,7 @@ describe("SingleLevelDropdown tests", () => {
       />,
     );
 
-    await waitFor(() => expect(useState).toBeCalledWith("U"));
+    await waitFor(() => expect(useState).toBeCalledWith("G"));
   });
 
   test("when localstorage has no value, U is passed to useState", async () => {


### PR DESCRIPTION
In this PR we fixed can't immediately search for graduate courses when you click submit on the first try: "When I first attempt to view graduate-only courses, the search returns undergraduate courses as well."
http://courses-qa.dokku-06.cs.ucsb.edu
https://courses-qa.dokku-06.cs.ucsb.edu

With this change, we should now be able to:
- view graduate-only courses on my first try after refreshing the page.
- view any other level courses on my first try.

<img width="1413" alt="Screen Shot 2024-02-28 at 1 22 11 AM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-2/assets/124765197/0cdca922-9b65-446d-9ca8-ca9eb071773c">

Closes #12 
