### PR TITLE
BUG: Deleting a personal schedule doesn't delete associated PSCourses

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -1,12 +1,12 @@
 package edu.ucsb.cs156.courses.controllers;
 
-import edu.ucsb.cs156.courses.entities.PersonalSchedule;
 import edu.ucsb.cs156.courses.entities.PSCourse;
+import edu.ucsb.cs156.courses.entities.PersonalSchedule;
 import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
 import edu.ucsb.cs156.courses.models.CurrentUser;
-import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
 import edu.ucsb.cs156.courses.repositories.PSCourseRepository;
+import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -121,7 +121,7 @@ public class PersonalSchedulesController extends ApiController {
     personalscheduleRepository.delete(personalschedule);
 
     Iterable<PSCourse> coursesToDelete = coursesRepository.findAllByPsId(id);
-    for(PSCourse course: coursesToDelete) {
+    for (PSCourse course : coursesToDelete) {
       coursesRepository.delete(course);
     }
 
@@ -140,7 +140,7 @@ public class PersonalSchedulesController extends ApiController {
     personalscheduleRepository.delete(personalschedule);
 
     Iterable<PSCourse> coursesToDelete = coursesRepository.findAllByPsId(id);
-    for(PSCourse course: coursesToDelete) {
+    for (PSCourse course : coursesToDelete) {
       coursesRepository.delete(course);
     }
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -1,10 +1,12 @@
 package edu.ucsb.cs156.courses.controllers;
 
 import edu.ucsb.cs156.courses.entities.PersonalSchedule;
+import edu.ucsb.cs156.courses.entities.PSCourse;
 import edu.ucsb.cs156.courses.entities.User;
 import edu.ucsb.cs156.courses.errors.EntityNotFoundException;
 import edu.ucsb.cs156.courses.models.CurrentUser;
 import edu.ucsb.cs156.courses.repositories.PersonalScheduleRepository;
+import edu.ucsb.cs156.courses.repositories.PSCourseRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class PersonalSchedulesController extends ApiController {
 
   @Autowired PersonalScheduleRepository personalscheduleRepository;
+  @Autowired PSCourseRepository coursesRepository;
 
   @Operation(summary = "List all personal schedules")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -117,6 +120,11 @@ public class PersonalSchedulesController extends ApiController {
 
     personalscheduleRepository.delete(personalschedule);
 
+    Iterable<PSCourse> coursesToDelete = coursesRepository.findAllByPsId(id);
+    for(PSCourse course: coursesToDelete) {
+      coursesRepository.delete(course);
+    }
+
     return genericMessage("PersonalSchedule with id %s deleted".formatted(id));
   }
 
@@ -130,6 +138,11 @@ public class PersonalSchedulesController extends ApiController {
             .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
 
     personalscheduleRepository.delete(personalschedule);
+
+    Iterable<PSCourse> coursesToDelete = coursesRepository.findAllByPsId(id);
+    for(PSCourse course: coursesToDelete) {
+      coursesRepository.delete(course);
+    }
 
     return genericMessage("PersonalSchedule with id %s deleted".formatted(id));
   }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -388,19 +388,12 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
             .build();
     when(personalscheduleRepository.findByIdAndUser(eq(15L), eq(u))).thenReturn(Optional.of(ps1));
 
-    PSCourse c1 = 
-        PSCourse.builder()
-            .id(10L)
-            .user(u)
-            .enrollCd("08078")
-            .psId(15L)
-            .build();
+    PSCourse c1 = PSCourse.builder().id(10L).user(u).enrollCd("08078").psId(15L).build();
 
     ArrayList<PSCourse> coursesToDelete = new ArrayList<>();
     coursesToDelete.add(c1);
 
     when(coursesRepository.findAllByPsId(eq(15L))).thenReturn(coursesToDelete);
-
 
     // act
     MvcResult response =
@@ -495,13 +488,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
             .build();
     when(personalscheduleRepository.findById(eq(16L))).thenReturn(Optional.of(ps1));
 
-    PSCourse c1 = 
-        PSCourse.builder()
-            .id(10L)
-            .user(otherUser)
-            .enrollCd("08078")
-            .psId(16L)
-            .build();
+    PSCourse c1 = PSCourse.builder().id(10L).user(otherUser).enrollCd("08078").psId(16L).build();
 
     ArrayList<PSCourse> coursesToDelete = new ArrayList<>();
     coursesToDelete.add(c1);

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -395,7 +395,12 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
             .enrollCd("08078")
             .psId(15L)
             .build();
-    when(coursesRepository.findByIdAndUser(eq(10L), eq(u))).thenReturn(Optional.of(c1));
+
+    ArrayList<PSCourse> coursesToDelete = new ArrayList<>();
+    coursesToDelete.add(c1);
+
+    when(coursesRepository.findAllByPsId(eq(15L))).thenReturn(coursesToDelete);
+
 
     // act
     MvcResult response =
@@ -407,21 +412,9 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
     // assert
     verify(personalscheduleRepository, times(1)).findByIdAndUser(15L, u);
     verify(personalscheduleRepository, times(1)).delete(ps1);
+    verify(coursesRepository, times(1)).delete(c1);
     Map<String, Object> json = responseToJson(response);
     assertEquals("PersonalSchedule with id 15 deleted", json.get("message"));
-    
-    // act
-    MvcResult response2 =
-        mockMvc
-            .perform(delete("/api/courses/user?id=10").with(csrf()))
-            .andExpect(status().isNotFound())
-            .andReturn();
-    
-    // assert
-    verify(coursesRepository.findByIdAndUser(10L, u));
-    json = responseToJson(response2);
-    assertEquals("EntityNotFoundException", json.get("type"));
-    //assertEquals("PSCourse with id 10 not found", json.get("message"));
   }
 
   @WithMockUser(roles = {"USER"})
@@ -502,6 +495,19 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
             .build();
     when(personalscheduleRepository.findById(eq(16L))).thenReturn(Optional.of(ps1));
 
+    PSCourse c1 = 
+        PSCourse.builder()
+            .id(10L)
+            .user(otherUser)
+            .enrollCd("08078")
+            .psId(16L)
+            .build();
+
+    ArrayList<PSCourse> coursesToDelete = new ArrayList<>();
+    coursesToDelete.add(c1);
+
+    when(coursesRepository.findAllByPsId(eq(16L))).thenReturn(coursesToDelete);
+
     // act
     MvcResult response =
         mockMvc
@@ -512,6 +518,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
     // assert
     verify(personalscheduleRepository, times(1)).findById(16L);
     verify(personalscheduleRepository, times(1)).delete(ps1);
+    verify(coursesRepository, times(1)).delete(c1);
     Map<String, Object> output = responseToJson(response);
     assertEquals("PersonalSchedule with id 16 deleted", output.get("message"));
   }


### PR DESCRIPTION
In this PR, we fix the bug that deleting a Personal Schedule does not delete associated courses. 
This was fixed for both user deleting their own schedule and admin deleting another user's schedule.

Existing tests for Personal Schedule are added upon to test this functionality.

[Dev Deployment](https://courses-aqiu28517-dev.dokku-06.cs.ucsb.edu/)

Closes #9 