### PR TITLE
REFACTOR: Simplify "Personal schedule" navigation

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -56,36 +56,20 @@ export default function AppNavbar({
 
             <Nav className="mr-auto">
               {hasRole(currentUser, "ROLE_USER") && (
-                <NavDropdown
-                  title="Personal Schedules"
-                  id="appnavbar-personalschedules-dropdown"
-                  data-testid="appnavbar-personalschedules-dropdown"
+                <Nav.Link
+                  href="/personalschedules/list"
+                  data-testid="appnavbar-personalschedules-list"
                 >
-                  <NavDropdown.Item
-                    href="/personalschedules/create"
-                    data-testid="appnavbar-personalschedules-create"
-                  >
-                    Add Schedule
-                  </NavDropdown.Item>
-                  <NavDropdown.Item
-                    href="/personalschedules/list"
-                    data-testid="appnavbar-personalschedules-list"
-                  >
-                    All Schedules
-                  </NavDropdown.Item>
-                  <NavDropdown.Item
-                    href="/courses/create"
-                    data-testid="appnavbar-courses-create"
-                  >
-                    Add Course
-                  </NavDropdown.Item>
-                  <NavDropdown.Item
-                    href="/courses/list"
-                    data-testid="appnavbar-courses-list"
-                  >
-                    All Courses
-                  </NavDropdown.Item>
-                </NavDropdown>
+                  Personal Schedules{" "}
+                </Nav.Link>
+              )}
+              {hasRole(currentUser, "ROLE_USER") && (
+                <Nav.Link
+                  href="/courses/list"
+                  data-testid="appnavbar-courses-list"
+                >
+                  Courses
+                </Nav.Link>
               )}
             </Nav>
 

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -60,7 +60,7 @@ export default function AppNavbar({
                   href="/personalschedules/list"
                   data-testid="appnavbar-personalschedules-list"
                 >
-                  Personal Schedules{" "}
+                  Personal Schedules
                 </Nav.Link>
               )}
               {hasRole(currentUser, "ROLE_USER") && (

--- a/frontend/src/main/pages/Courses/PSCourseIndexPage.js
+++ b/frontend/src/main/pages/Courses/PSCourseIndexPage.js
@@ -4,6 +4,7 @@ import { useBackend } from "main/utils/useBackend";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import CourseTable from "main/components/Courses/CourseTable";
 import { useCurrentUser } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
 
 export default function CoursesIndexPage() {
   const currentUser = useCurrentUser();
@@ -23,11 +24,20 @@ export default function CoursesIndexPage() {
     [],
   );
 
+  const createButton = () => {
+    return (
+      <Button variant="primary" href="/courses/create" style={{}}>
+        Add New Course
+      </Button>
+    );
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Courses</h1>
         <CourseTable courses={courses} currentUser={currentUser} />
+        {createButton()}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesDetailsPage.js
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import PersonalSchedulesTable from "main/components/PersonalSchedules/PersonalSchedulesTable";
 import PersonalSectionsTable from "main/components/PersonalSections/PersonalSectionsTable";
 import { useBackend, _useBackendMutation } from "main/utils/useBackend";
+import { Button } from "react-bootstrap";
 
 export default function PersonalSchedulesDetailsPage() {
   let { id } = useParams();
@@ -23,6 +24,13 @@ export default function PersonalSchedulesDetailsPage() {
       },
     },
   );
+  const createButton = () => {
+    return (
+      <Button variant="primary" href="/personalschedules/list" style={{}}>
+        Back
+      </Button>
+    );
+  };
 
   const { data: personalSection } = useBackend(
     // Stryker disable all : hard to test for query caching
@@ -52,6 +60,7 @@ export default function PersonalSchedulesDetailsPage() {
             <PersonalSectionsTable personalSections={personalSection} />
           )}
         </p>
+        {createButton()}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -1,11 +1,20 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { Button } from "react-bootstrap";
 
 export default function PersonalSchedulesEditPage() {
+  const createButton = () => {
+    return (
+      <Button variant="primary" href="/personalschedules/list" style={{}}>
+        Back
+      </Button>
+    );
+  };
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Personal Schedules</h1>
         <p>This is where the edit page will go</p>
+        {createButton()}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesIndexPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesIndexPage.js
@@ -4,6 +4,7 @@ import { useBackend } from "main/utils/useBackend";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import PersonalSchedulesTable from "main/components/PersonalSchedules/PersonalSchedulesTable";
 import { useCurrentUser } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
 
 export default function PersonalSchedulesIndexPage() {
   const currentUser = useCurrentUser();
@@ -18,7 +19,13 @@ export default function PersonalSchedulesIndexPage() {
     { method: "GET", url: "/api/personalschedules/all" },
     [],
   );
-
+  const createButton = () => {
+    return (
+      <Button variant="primary" href="/personalschedules/create" style={{}}>
+        Add New Personal Schedule
+      </Button>
+    );
+  };
   return (
     <BasicLayout>
       <div className="pt-2">
@@ -27,6 +34,7 @@ export default function PersonalSchedulesIndexPage() {
           personalSchedules={personalSchedules}
           currentUser={currentUser}
         />
+        {createButton()}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -178,7 +178,7 @@ describe("AppNavbar tests", () => {
     expect(screen.queryByTestId(/AppNavbarLocalhost/i)).toBeNull();
   });
 
-  test("renders the PersonalSchedules menu correctly", async () => {
+  test("renders Personal Schedules and Courses links correctly for regular logged in user", async () => {
     const currentUser = currentUserFixtures.userOnly;
     const systemInfo = systemInfoFixtures.showingBoth;
 
@@ -196,25 +196,13 @@ describe("AppNavbar tests", () => {
       </QueryClientProvider>,
     );
 
+    expect(await screen.findByText("Personal Schedules")).toBeInTheDocument();
     expect(
-      await screen.findByTestId("appnavbar-personalschedules-dropdown"),
-    ).toBeInTheDocument();
-    const dropdown = screen.getByTestId("appnavbar-personalschedules-dropdown");
-    const aElement = dropdown.querySelector("a");
-    expect(aElement).toBeInTheDocument();
-    aElement?.click();
-
-    expect(
-      await screen.findByTestId("appnavbar-personalschedules-list"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId(/appnavbar-personalschedules-create/),
+      screen.getByTestId("appnavbar-personalschedules-list"),
     ).toBeInTheDocument();
 
-    expect(
-      await screen.findByTestId("appnavbar-courses-list"),
-    ).toBeInTheDocument();
-    expect(screen.getByTestId(/appnavbar-courses-create/)).toBeInTheDocument();
+    expect(await screen.findByText("Courses")).toBeInTheDocument();
+    expect(screen.getByTestId("appnavbar-courses-list")).toBeInTheDocument();
   });
 
   test("renders the Course Description menu correctly", async () => {

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -198,11 +198,13 @@ describe("AppNavbar tests", () => {
 
     expect(await screen.findByText("Personal Schedules")).toBeInTheDocument();
     expect(
-      screen.getByTestId("appnavbar-personalschedules-list"),
+      await screen.findByTestId("appnavbar-personalschedules-list"),
     ).toBeInTheDocument();
 
     expect(await screen.findByText("Courses")).toBeInTheDocument();
-    expect(screen.getByTestId("appnavbar-courses-list")).toBeInTheDocument();
+    expect(
+      await screen.findByTestId("appnavbar-courses-list"),
+    ).toBeInTheDocument();
   });
 
   test("renders the Course Description menu correctly", async () => {

--- a/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
+++ b/frontend/src/tests/pages/Courses/CoursesIndexPage.test.js
@@ -9,6 +9,7 @@ import CoursesIndexPage from "main/pages/Courses/PSCourseIndexPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { coursesFixtures } from "fixtures/pscourseFixtures";
+import userEvent from "@testing-library/user-event";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -98,6 +99,25 @@ describe("CoursesIndexPage tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
       "26",
     );
+  });
+
+  test("renders 'Add New Course' button", () => {
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/courses/user/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CoursesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const addButton = screen.getByRole("button", { name: /add new course/i });
+    expect(addButton).toBeInTheDocument();
+
+    userEvent.click(addButton);
   });
 
   test("renders two courses without crashing for admin user", async () => {

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesDetailsPage.test.js
@@ -7,6 +7,7 @@ import PersonalSchedulesDetailsPage from "main/pages/PersonalSchedules/PersonalS
 import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import userEvent from "@testing-library/user-event";
 
 const mockNavigate = jest.fn();
 jest.mock("react-router-dom", () => {
@@ -147,5 +148,26 @@ describe("PersonalSchedulesDetailsPage tests", () => {
     expect(
       screen.getByTestId(`PersonalSectionsTable-cell-row-0-col-instructor`),
     ).toHaveTextContent("WANG L C");
+  });
+
+  test("renders 'Back' button", () => {
+    const queryClient = new QueryClient();
+    axiosMock.onGet(`/api/personalschedules?id=17`).reply(200, []);
+    axiosMock.onGet(`api/personalSections/all?psId=17`).reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSchedulesDetailsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const backButton = screen.getByRole("button", { name: /back/i });
+    expect(backButton).toBeInTheDocument();
+
+    // Optional: Test button functionality
+    userEvent.click(backButton);
+    // Add your assertions here to ensure that clicking the button triggers the expected action.
   });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
@@ -7,6 +7,7 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import userEvent from "@testing-library/user-event";
 
 describe("PersonalSchedulesEditPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
@@ -18,6 +19,11 @@ describe("PersonalSchedulesEditPage tests", () => {
     .reply(200, systemInfoFixtures.showingNeither);
 
   const queryClient = new QueryClient();
+
+  beforeEach(() => {
+    axiosMock.reset();
+  });
+
   test("renders without crashing", () => {
     render(
       <QueryClientProvider client={queryClient}>
@@ -26,5 +32,25 @@ describe("PersonalSchedulesEditPage tests", () => {
         </MemoryRouter>
       </QueryClientProvider>,
     );
+  });
+  test("renders 'Back' button", () => {
+    const queryClient = new QueryClient();
+    axiosMock.onGet(`/api/personalschedules?id=17`).reply(200, []);
+    axiosMock.onGet(`api/personalSections/all?psId=17`).reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSchedulesEditPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const backButton = screen.getByRole("button", { name: /back/i });
+    expect(backButton).toBeInTheDocument();
+
+    // Optional: Test button functionality
+    userEvent.click(backButton);
+    // Add your assertions here to ensure that clicking the button triggers the expected action.
   });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesIndexPage.test.js
@@ -9,6 +9,7 @@ import PersonalSchedulesIndexPage from "main/pages/PersonalSchedules/PersonalSch
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import { personalScheduleFixtures } from "fixtures/personalScheduleFixtures";
+import userEvent from "@testing-library/user-event";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -99,6 +100,27 @@ describe("PersonalSchedulesIndexPage tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
       "3",
     );
+  });
+
+  test("renders 'Add New Personal Schedule' button", () => {
+    setupUserOnly();
+    const queryClient = new QueryClient();
+    axiosMock.onGet("/api/personalschedules/all").reply(200, []);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PersonalSchedulesIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const addButton = screen.getByRole("button", {
+      name: /add new personal schedule/i,
+    });
+    expect(addButton).toBeInTheDocument();
+
+    userEvent.click(addButton);
   });
 
   test("renders three PersonalSchedules without crashing for admin user", async () => {


### PR DESCRIPTION
In this PR, we changed the dropdown for Personal schedule nav bar into two links that can just lead you to all personal schedule and all courses. Inside both, you can click on the Add New PS to create ps and/or Add New Course to create courses.

web dev: https://courses-jiaqiguan2003-dev.dokku-06.cs.ucsb.edu

### new nav bar instead of dropdown:
<img width="838" alt="Screen Shot 2024-03-06 at 11 42 30 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-2/assets/124765197/c5fb3514-755b-43ec-9853-e56e350d1b7d">

### click on Personal Schedules will lead to this page and it includes a button to create new PS:
<img width="832" alt="Screen Shot 2024-03-06 at 11 44 02 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-2/assets/124765197/41392a90-f24b-4734-a3f3-299824be9f55">


### click on Courses will lead to this page and it includes a button to create new course:
<img width="841" alt="Screen Shot 2024-03-06 at 11 44 29 PM" src="https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-2/assets/124765197/ce3b3e12-94df-4b6c-99b2-d228b40a127e">


Closes #13 
