### PR TITLE
FEATURE: Add edit page for personal schedules

### DIFF
--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -34,6 +34,13 @@ function PersonalScheduleForm({
     }.quarters[0],
   );
 
+  const quarterMap = {
+    1: "W",
+    2: "S",
+    3: "M",
+    4: "F",
+  };
+
   return (
     <Form onSubmit={handleSubmit(submitAction)}>
       {initialPersonalSchedule && (
@@ -85,15 +92,32 @@ function PersonalScheduleForm({
           {errors.description?.message}
         </Form.Control.Feedback>
       </Form.Group>
-      <Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
-        <SingleQuarterDropdown
-          quarter={quarter}
-          setQuarter={setQuarter}
-          controlId={"PersonalScheduleForm-quarter"}
-          label={"Quarter"}
-          quarters={quarters}
-        />
-      </Form.Group>
+      {initialPersonalSchedule ? (
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="quarter">Quarter</Form.Label>
+          <Form.Control
+            data-testid="PersonalScheduleForm-quarter"
+            id="quarter"
+            type="text"
+            {...register("quarter")}
+            value={
+              quarterMap[initialPersonalSchedule.quarter.substring(4, 5)] +
+              initialPersonalSchedule.quarter.substring(2, 4)
+            }
+            disabled
+          />
+        </Form.Group>
+      ) : (
+        <Form.Group className="mb-3" data-testid="PersonalScheduleForm-quarter">
+          <SingleQuarterDropdown
+            quarter={quarter}
+            setQuarter={setQuarter}
+            controlId={"PersonalScheduleForm-quarter"}
+            label={"Quarter"}
+            quarters={quarters}
+          />
+        </Form.Group>
+      )}
 
       <Button type="submit" data-testid="PersonalScheduleForm-submit">
         {buttonLabel}

--- a/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
+++ b/frontend/src/main/components/Quarters/SingleQuarterDropdown.js
@@ -14,6 +14,7 @@ import { Form } from "react-bootstrap";
 //  { yyyyq :"20222", qyy: "S22"}]
 
 function SingleQuarterDropdown({
+  quarter,
   quarters,
   setQuarter,
   controlId,
@@ -27,7 +28,7 @@ function SingleQuarterDropdown({
 
   const [quarterState, setQuarterState] = useState(
     // Stryker disable next-line all : not sure how to test/mock local storage
-    localSearchQuarter || quarters[0].yyyyq,
+    quarter.yyyq || localSearchQuarter || quarters[0].yyyyq,
   );
 
   const handleQuarterOnChange = (event) => {

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -26,7 +26,7 @@ export default function PersonalSchedulesEditPage() {
     _status,
   } = useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/personalschedules?id=${id}"],
+    [`/api/personalschedules?id=${id}`],
     {
       // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
       method: "GET",
@@ -77,7 +77,7 @@ export default function PersonalSchedulesEditPage() {
     objectToAxiosParams,
     { onSuccess },
     // Stryker disable next-line all : hard to set up test for caching
-    ["/api/personalschedules/id=${id}"],
+    [`/api/personalschedules/id=${id}`],
   );
 
   const { isSuccess } = mutation;

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -16,7 +16,7 @@ export default function PersonalSchedulesEditPage() {
       </Button>
     );
   };
-  
+
   let { id } = useParams();
   const currentUser = useCurrentUser();
 
@@ -110,4 +110,3 @@ export default function PersonalSchedulesEditPage() {
     </BasicLayout>
   );
 }
-

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -1,12 +1,15 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
 import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
+import CourseTable from "main/components/Courses/CourseTable";
 import { Navigate } from "react-router-dom";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
+import { useCurrentUser } from "main/utils/currentUser";
 
 export default function PersonalSchedulesEditPage(storybook = false) {
   let { id } = useParams();
+  const currentUser = useCurrentUser();
 
   const { data: personalSchedule, _error, _status } =
     useBackend(
@@ -19,6 +22,21 @@ export default function PersonalSchedulesEditPage(storybook = false) {
           id,
         },
       },
+    );
+
+    const {
+      data: courses,
+      error: _PCerror,
+      status: _PCstatus,
+    } = useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      [`/api/courses/user/psid/all?psId=${id}`],
+      {
+        // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
+        method: "GET",
+        url: `/api/courses/user/psid/all?psId=${id}`,
+      },
+      [],
     );
   
   const objectToAxiosParams = (personalSchedule) => ({
@@ -52,23 +70,17 @@ export default function PersonalSchedulesEditPage(storybook = false) {
   const { isSuccess } = mutation;
 
   const onSubmit = async (data) => {
-    const quarter = {
-      quarter: localStorage["PersonalScheduleForm-quarter"],
-    };
-    console.log(quarter);
-    const dataFinal = Object.assign(data, quarter);
-    console.log(dataFinal);
-    mutation.mutate(dataFinal);
+    mutation.mutate(data);
   };
 
-  if (isSuccess && !storybook) {
+  if (isSuccess) {
     return <Navigate to="/personalschedules/list" />;
   }
 
   return (
     <BasicLayout>
       <div className="pt-2">
-      <h1>Edit Personal Schedule</h1>
+        <h1>Edit Personal Schedule</h1>
         {personalSchedule && (
           <PersonalScheduleForm
             submitAction={onSubmit}
@@ -76,6 +88,10 @@ export default function PersonalSchedulesEditPage(storybook = false) {
             initialPersonalSchedule={personalSchedule}
           />
         )}
+        <p className="py-5">
+          <h1>Courses</h1>
+          <CourseTable courses={courses} currentUser={currentUser} />
+        </p>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -2,7 +2,6 @@ import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import { useParams } from "react-router-dom";
 import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
 import { Navigate } from "react-router-dom";
-import CourseTable from "main/components/Courses/CourseTable";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 
@@ -57,9 +56,9 @@ export default function PersonalSchedulesEditPage(storybook = false) {
       quarter: localStorage["PersonalScheduleForm-quarter"],
     };
     console.log(quarter);
-    const data2 = Object.assign(data, quarter);
-    console.log(data2);
-    mutation.mutate(data2);
+    const dataFinal = Object.assign(data, quarter);
+    console.log(dataFinal);
+    mutation.mutate(dataFinal);
   };
 
   if (isSuccess && !storybook) {

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -7,7 +7,7 @@ import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 import { useCurrentUser } from "main/utils/currentUser";
 
-export default function PersonalSchedulesEditPage(storybook = false) {
+export default function PersonalSchedulesEditPage() {
   let { id } = useParams();
   const currentUser = useCurrentUser();
 

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -11,34 +11,38 @@ export default function PersonalSchedulesEditPage() {
   let { id } = useParams();
   const currentUser = useCurrentUser();
 
-  const { data: personalSchedule, _error, _status } =
-    useBackend(
-      // Stryker disable next-line all : don't test internal caching of React Query
-      ['/api/personalschedules?id=${id}'],
-      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
-        method: "GET",
-        url: `/api/personalschedules`,
-        params: {
-          id,
-        },
+  const {
+    data: personalSchedule,
+    _error,
+    _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/personalschedules?id=${id}"],
+    {
+      // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+      method: "GET",
+      url: `/api/personalschedules`,
+      params: {
+        id,
       },
-    );
+    },
+  );
 
-    const {
-      data: courses,
-      error: _PCerror,
-      status: _PCstatus,
-    } = useBackend(
-      // Stryker disable next-line all : don't test internal caching of React Query
-      [`/api/courses/user/psid/all?psId=${id}`],
-      {
-        // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
-        method: "GET",
-        url: `/api/courses/user/psid/all?psId=${id}`,
-      },
-      [],
-    );
-  
+  const {
+    data: courses,
+    error: _PCerror,
+    status: _PCstatus,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    [`/api/courses/user/psid/all?psId=${id}`],
+    {
+      // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
+      method: "GET",
+      url: `/api/courses/user/psid/all?psId=${id}`,
+    },
+    [],
+  );
+
   const objectToAxiosParams = (personalSchedule) => ({
     url: "/api/personalschedules",
     method: "PUT",
@@ -50,7 +54,7 @@ export default function PersonalSchedulesEditPage() {
       name: personalSchedule.name,
       description: personalSchedule.description,
       quarter: personalSchedule.quarter,
-    }
+    },
   });
 
   const onSuccess = (personalSchedule) => {

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -6,8 +6,17 @@ import { Navigate } from "react-router-dom";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
 import { useCurrentUser } from "main/utils/currentUser";
+import { Button } from "react-bootstrap";
 
 export default function PersonalSchedulesEditPage() {
+  const createButton = () => {
+    return (
+      <Button variant="primary" href="/personalschedules/list" style={{}}>
+        Back
+      </Button>
+    );
+  };
+  
   let { id } = useParams();
   const currentUser = useCurrentUser();
 
@@ -85,6 +94,7 @@ export default function PersonalSchedulesEditPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Edit Personal Schedule</h1>
+        {createButton()}
         {personalSchedule && (
           <PersonalScheduleForm
             submitAction={onSubmit}

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -5,11 +5,9 @@ import { Navigate } from "react-router-dom";
 import CourseTable from "main/components/Courses/CourseTable";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { toast } from "react-toastify";
-import { useCurrentUser } from "main/utils/currentUser";
 
-export default function PersonalSchedulesEditPage() {
+export default function PersonalSchedulesEditPage(storybook = false) {
   let { id } = useParams();
-  const currentUser = useCurrentUser();
 
   const { data: personalSchedule, _error, _status } =
     useBackend(
@@ -23,18 +21,6 @@ export default function PersonalSchedulesEditPage() {
         },
       },
     );
-
-  const { data: courses, _PSerror, _PSstatus } = 
-    useBackend(
-    // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/courses/user/psId/all?psId=${id}"],
-    {
-      // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
-      method: "GET",
-      url: "/api/courses/user/psId/all?psId=${id}",
-    },
-    [],
-  );
   
   const objectToAxiosParams = (personalSchedule) => ({
     url: "/api/personalschedules",
@@ -43,7 +29,7 @@ export default function PersonalSchedulesEditPage() {
       id: personalSchedule.id,
     },
     data: {
-      id: personalSchedule.id,
+      user: personalSchedule.user,
       name: personalSchedule.name,
       description: personalSchedule.description,
       quarter: personalSchedule.quarter,
@@ -67,34 +53,30 @@ export default function PersonalSchedulesEditPage() {
   const { isSuccess } = mutation;
 
   const onSubmit = async (data) => {
-    mutation.mutate(data);
+    const quarter = {
+      quarter: localStorage["PersonalScheduleForm-quarter"],
+    };
+    console.log(quarter);
+    const data2 = Object.assign(data, quarter);
+    console.log(data2);
+    mutation.mutate(data2);
   };
 
-//  const onSubmit = async (data) => {
-    //const quarter = {
-      //quarter: localStorage["PersonalScheduleForm-quarter"],
-    //};
-    //console.log(quarter);
-    //const dataFinal = Object.assign(data, quarter);
-    //console.log(dataFinal);
-    //mutation.mutate(dataFinal);
-  //};
-
-  if (isSuccess) {
+  if (isSuccess && !storybook) {
     return <Navigate to="/personalschedules/list" />;
   }
 
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Edit Personal Schedule</h1>
-
-        personalSchedule && <PersonalScheduleForm initialPersonalSchedule={personalSchedule} submitAction={onSubmit} buttonLabel="Update"/>
-
-        <p className="py-5">
-          <h1>Courses</h1>
-          <CourseTable courses={courses} currentUser={currentUser} />
-        </p>
+      <h1>Edit Personal Schedule</h1>
+        {personalSchedule && (
+          <PersonalScheduleForm
+            submitAction={onSubmit}
+            buttonLabel={"Update"}
+            initialPersonalSchedule={personalSchedule}
+          />
+        )}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -1,11 +1,100 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import { useParams } from "react-router-dom";
+import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalScheduleForm";
+import { Navigate } from "react-router-dom";
+import CourseTable from "main/components/Courses/CourseTable";
+import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+import { useCurrentUser } from "main/utils/currentUser";
 
 export default function PersonalSchedulesEditPage() {
+  let { id } = useParams();
+  const currentUser = useCurrentUser();
+
+  const { data: personalSchedule, _error, _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ['/api/personalschedules?id=${id}'],
+      {  // Stryker disable next-line all : GET is the default, so changing this to "" doesn't introduce a bug
+        method: "GET",
+        url: `/api/personalschedules`,
+        params: {
+          id
+        }
+      }
+    );
+
+  const { data: courses, _PSerror, _PSstatus } = 
+    useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/courses/user/all"],
+    {
+      // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
+      method: "GET",
+      url: "/api/courses/user/all",
+    },
+    [],
+  );
+  
+  const objectToAxiosParams = (personalSchedule) => ({
+    url: "/api/personalschedules/put",
+    method: "PUT",
+    params: {
+      id: personalSchedule.id,
+    },
+    data: {
+      id: personalSchedule.id,
+      name: personalSchedule.name,
+      description: personalSchedule.description,
+      quarter: personalSchedule.quarter,
+    }
+  });
+
+  const onSuccess = (personalSchedule) => {
+    toast(
+      `PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name} description: ${personalSchedule.description} quarter: ${personalSchedule.quarter}`,
+    );
+    console.log(personalSchedule.quarter);
+  };
+
+  const onError = (error) => {
+    toast(`Error: ${error.response.data.message}`);
+  };
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+    { onSuccess },
+    // Stryker disable next-line all : hard to set up test for caching
+    ["/api/personalschedules/id=${id}"],
+  );
+
+  const { isSuccess } = mutation;
+
+  const onSubmit = async (data) => {
+    const quarter = {
+      quarter: localStorage["PersonalScheduleForm-quarter"],
+    };
+    console.log(quarter);
+    const dataFinal = Object.assign(data, quarter);
+    console.log(dataFinal);
+    mutation.mutate(dataFinal);
+  };
+
+  if (isSuccess) {
+    return <Navigate to="/personalschedules/list" />;
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Personal Schedules</h1>
-        <p>This is where the edit page will go</p>
+        <h1>Edit Personal Schedule</h1>
+
+        personalSchedule && <PersonalScheduleForm initialPersonalSchedule={personalSchedule} submitAction={onSubmit} buttonLabel="Update"/>
+
+        <p className="py-5">
+          <h1>Courses</h1>
+          <CourseTable courses={courses} currentUser={currentUser} />
+        </p>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -19,25 +19,25 @@ export default function PersonalSchedulesEditPage() {
         method: "GET",
         url: `/api/personalschedules`,
         params: {
-          id
-        }
-      }
+          id,
+        },
+      },
     );
 
   const { data: courses, _PSerror, _PSstatus } = 
     useBackend(
     // Stryker disable next-line all : don't test internal caching of React Query
-    ["/api/courses/user/all"],
+    ["/api/courses/user/psId/all?psId=${id}"],
     {
       // Stryker disable next-line StringLiteral : GET is default, so replacing with "" is an equivalent mutation
       method: "GET",
-      url: "/api/courses/user/all",
+      url: "/api/courses/user/psId/all?psId=${id}",
     },
     [],
   );
   
   const objectToAxiosParams = (personalSchedule) => ({
-    url: "/api/personalschedules/put",
+    url: "/api/personalschedules",
     method: "PUT",
     params: {
       id: personalSchedule.id,
@@ -52,13 +52,9 @@ export default function PersonalSchedulesEditPage() {
 
   const onSuccess = (personalSchedule) => {
     toast(
-      `PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name} description: ${personalSchedule.description} quarter: ${personalSchedule.quarter}`,
+      `PersonalSchedule Updated - id: ${personalSchedule.id} name: ${personalSchedule.name}`,
     );
     console.log(personalSchedule.quarter);
-  };
-
-  const onError = (error) => {
-    toast(`Error: ${error.response.data.message}`);
   };
 
   const mutation = useBackendMutation(
@@ -71,14 +67,18 @@ export default function PersonalSchedulesEditPage() {
   const { isSuccess } = mutation;
 
   const onSubmit = async (data) => {
-    const quarter = {
-      quarter: localStorage["PersonalScheduleForm-quarter"],
-    };
-    console.log(quarter);
-    const dataFinal = Object.assign(data, quarter);
-    console.log(dataFinal);
-    mutation.mutate(dataFinal);
+    mutation.mutate(data);
   };
+
+//  const onSubmit = async (data) => {
+    //const quarter = {
+      //quarter: localStorage["PersonalScheduleForm-quarter"],
+    //};
+    //console.log(quarter);
+    //const dataFinal = Object.assign(data, quarter);
+    //console.log(dataFinal);
+    //mutation.mutate(dataFinal);
+  //};
 
   if (isSuccess) {
     return <Navigate to="/personalschedules/list" />;

--- a/frontend/src/stories/pages/PersonalSchedulesEditPage.stories.js
+++ b/frontend/src/stories/pages/PersonalSchedulesEditPage.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
 
 export default {

--- a/frontend/src/stories/pages/PersonalSchedulesEditPage.stories.js
+++ b/frontend/src/stories/pages/PersonalSchedulesEditPage.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { personalSchedulesFixtures } from "fixtures/personalSchedulesFixtures";
+import { rest } from "msw";
+
+import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
+
+export default {
+    title: 'pages/PersonalSchedules/PersonalSchedulesEditPage',
+    component: PersonalSchedulesEditPage
+};
+
+const Template = () => <PersonalSchedulesEditPage storybook={true}/>;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res( ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.get('/api/personalschedules', (_req, res, ctx) => {
+            return res(ctx.json(personalSchedulesFixtures.twoPersonalSchedules[0]));
+        }),
+        rest.put('/api/personalschedules', async (req, res, ctx) => {
+            var reqBody = await req.text();
+            window.alert("PUT: " + req.url + " and body: " + reqBody);
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ],
+}

--- a/frontend/src/stories/pages/PersonalSchedulesEditPage.stories.js
+++ b/frontend/src/stories/pages/PersonalSchedulesEditPage.stories.js
@@ -1,34 +1,11 @@
 import React from 'react';
-import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
-import { personalSchedulesFixtures } from "fixtures/personalSchedulesFixtures";
-import { rest } from "msw";
-
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
 
 export default {
-    title: 'pages/PersonalSchedules/PersonalSchedulesEditPage',
-    component: PersonalSchedulesEditPage
+  title: "pages/PersonalSchedules/PersonalSchedulesEditPage",
+  component: PersonalSchedulesEditPage,
 };
 
-const Template = () => <PersonalSchedulesEditPage storybook={true}/>;
+const Template = () => <PersonalSchedulesEditPage storybook={true} />;
 
 export const Default = Template.bind({});
-Default.parameters = {
-    msw: [
-        rest.get('/api/currentUser', (_req, res, ctx) => {
-            return res( ctx.json(apiCurrentUserFixtures.userOnly));
-        }),
-        rest.get('/api/systemInfo', (_req, res, ctx) => {
-            return res(ctx.json(systemInfoFixtures.showingNeither));
-        }),
-        rest.get('/api/personalschedules', (_req, res, ctx) => {
-            return res(ctx.json(personalSchedulesFixtures.twoPersonalSchedules[0]));
-        }),
-        rest.put('/api/personalschedules', async (req, res, ctx) => {
-            var reqBody = await req.text();
-            window.alert("PUT: " + req.url + " and body: " + reqBody);
-            return res(ctx.status(200),ctx.json({}));
-        }),
-    ],
-}

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -232,7 +232,6 @@ describe("PersonalScheduleForm tests", () => {
     });
   });
 
-
   test("Form has initialPersonalSchedule content with Spring quarter", async () => {
     const queryClient = new QueryClient();
     const content = {

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -195,4 +195,113 @@ describe("PersonalScheduleForm tests", () => {
       await screen.findByText("Max length 15 characters"),
     ).toBeInTheDocument();
   });
+
+  test("Form has initialPersonalSchedule content with Fall quarter", async () => {
+    const queryClient = new QueryClient();
+    const content = {
+      id: 17,
+      user: {
+        id: 1,
+        email: "phtcon@ucsb.edu",
+        googleSub: "115856948234298493496",
+        pictureUrl:
+          "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+        fullName: "Phill Conrad",
+        givenName: "Phill",
+        familyName: "Conrad",
+        emailVerified: true,
+        locale: "en",
+        hostedDomain: "ucsb.edu",
+        admin: true,
+      },
+      description: "My Plan for Fall",
+      quarter: "20224",
+      name: "Fall Courses",
+    };
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <PersonalScheduleForm initialPersonalSchedule={content} />
+        </Router>
+      </QueryClientProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("PersonalScheduleForm-quarter")).toHaveValue(
+        "F22",
+      );
+    });
+  });
+
+
+  test("Form has initialPersonalSchedule content with Spring quarter", async () => {
+    const queryClient = new QueryClient();
+    const content = {
+      id: 17,
+      user: {
+        id: 1,
+        email: "phtcon@ucsb.edu",
+        googleSub: "115856948234298493496",
+        pictureUrl:
+          "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+        fullName: "Phill Conrad",
+        givenName: "Phill",
+        familyName: "Conrad",
+        emailVerified: true,
+        locale: "en",
+        hostedDomain: "ucsb.edu",
+        admin: true,
+      },
+      description: "My Plan for Spring",
+      quarter: "20222",
+      name: "Spring Courses",
+    };
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <PersonalScheduleForm initialPersonalSchedule={content} />
+        </Router>
+      </QueryClientProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("PersonalScheduleForm-quarter")).toHaveValue(
+        "S22",
+      );
+    });
+  });
+
+  test("Form has initialPersonalSchedule content with Summer quarter", async () => {
+    const queryClient = new QueryClient();
+    const content = {
+      id: 17,
+      user: {
+        id: 1,
+        email: "phtcon@ucsb.edu",
+        googleSub: "115856948234298493496",
+        pictureUrl:
+          "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+        fullName: "Phill Conrad",
+        givenName: "Phill",
+        familyName: "Conrad",
+        emailVerified: true,
+        locale: "en",
+        hostedDomain: "ucsb.edu",
+        admin: true,
+      },
+      description: "My Plan for M",
+      quarter: "20223",
+      name: "M Courses",
+    };
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Router>
+          <PersonalScheduleForm initialPersonalSchedule={content} />
+        </Router>
+      </QueryClientProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("PersonalScheduleForm-quarter")).toHaveValue(
+        "M22",
+      );
+    });
+  });
 });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -161,7 +161,7 @@ describe("PersonalSchedulesEditPage tests", () => {
 
           expect(quarterField).toBeInTheDocument();
 
-          //expect(quarterField).toHaveValue("20221");
+          expect(quarterField).toHaveValue("20221");
           expect(submitButton).toHaveTextContent("Update");
 
           fireEvent.change(nameField, { target: { value: "CS154" } });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
 
-import { coursesFixtures } from "fixtures/pscourseFixtures";
+//import { coursesFixtures } from "fixtures/pscourseFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
 
-//import { coursesFixtures } from "fixtures/pscourseFixtures";
+import { coursesFixtures } from "fixtures/pscourseFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
@@ -27,7 +27,7 @@ jest.mock('react-router-dom', () => {
         __esModule: true,
         ...originalModule,
         useParams: () => ({
-            id: 1,
+            id: 17,
         }),
         Navigate: (x) => { mockNavigate(x); return null; },
     };
@@ -44,7 +44,7 @@ describe("PersonalSchedulesEditPage tests", () => {
           axiosMock.resetHistory();
           axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
           axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-          axiosMock.onGet("/api/personalschedules", { params: { id: 1 } }).timeout();
+          axiosMock.onGet("/api/personalschedules", { params: { id: 17 } }).timeout();
       });
 
       const queryClient = new QueryClient();
@@ -74,17 +74,45 @@ describe("PersonalSchedulesEditPage tests", () => {
           axiosMock.resetHistory();
           axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
           axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-          axiosMock.onGet("/api/personalschedules", { params: { id: 1 } }).reply(200, {
-              id: 1,
-              name: "TestName",
-              description: "TestDescription",
-              quarter: "W08"
+          axiosMock.onGet("/api/personalschedules", { params: { id: 17 } }).reply(200, {
+              id: 17,
+              user: {
+                id: 1,
+                email: "phtcon@ucsb.edu",
+                googleSub: "115856948234298493496",
+                pictureUrl:
+                  "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+                fullName: "Phill Conrad",
+                givenName: "Phill",
+                familyName: "Conrad",
+                emailVerified: true,
+                locale: "en",
+                hostedDomain: "ucsb.edu",
+                admin: true,
+              },
+              description: "My Winter Courses",
+              quarter: "20221",
+              name: "CS156",
           });
           axiosMock.onPut('/api/personalschedules').reply(200, {
+            id: 17,
+            user: {
               id: 1,
-              name: "TestName6",
-              description: "TestDescription6",
-              quarter: "W08",
+              email: "phtcon@ucsb.edu",
+              googleSub: "115856948234298493496",
+              pictureUrl:
+                "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+              fullName: "Phill Conrad",
+              givenName: "Phill",
+              familyName: "Conrad",
+              emailVerified: true,
+              locale: "en",
+              hostedDomain: "ucsb.edu",
+              admin: true,
+            },
+            description: "Winter Course Plan",
+            quarter: "20221",
+            name: "CS154",
           });
       });
 
@@ -123,78 +151,116 @@ describe("PersonalSchedulesEditPage tests", () => {
           const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
           expect(idField).toBeInTheDocument();
-          expect(idField).toHaveValue("1");
+          expect(idField).toHaveValue("17");
+
           expect(nameField).toBeInTheDocument();
-          expect(nameField).toHaveValue("TestName");
+          expect(nameField).toHaveValue("CS156");
+
           expect(descriptionField).toBeInTheDocument();
-          expect(descriptionField).toHaveValue("TestDescription");
+          expect(descriptionField).toHaveValue("My Winter Courses");
+
           expect(quarterField).toBeInTheDocument();
 
+          //expect(quarterField).toHaveValue("20221");
           expect(submitButton).toHaveTextContent("Update");
 
-          fireEvent.change(nameField, { target: { value: "TestName6" } });
-          fireEvent.change(descriptionField, { target: { value: "TestDescription6" } });
+          fireEvent.change(nameField, { target: { value: "CS154" } });
+          fireEvent.change(descriptionField, { target: { value: "Winter Course Plan" } });
           fireEvent.click(submitButton);
 
           await waitFor(() => expect(mockToast).toBeCalled());
-          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 1 name: TestName6");
+          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 17 name: CS154");
 
-          expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
+          expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
 
           expect(axiosMock.history.put.length).toBe(1); // times called
-          expect(axiosMock.history.put[0].params).toEqual({ id : 1 });
+          expect(axiosMock.history.put[0].params).toEqual({ id : 17 });
           expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
-              id: 1,
-              name: "TestName6",
-              description: "TestDescription6",
-              quarter: "W08"
+            user: {
+                id: 1,
+                email: "phtcon@ucsb.edu",
+                googleSub: "115856948234298493496",
+                pictureUrl:
+                  "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+                fullName: "Phill Conrad",
+                givenName: "Phill",
+                familyName: "Conrad",
+                emailVerified: true,
+                locale: "en",
+                hostedDomain: "ucsb.edu",
+                admin: true,
+              },
+              name: "CS154",
+              description: "Winter Course Plan",
+              quarter: "20221",
           })); // posted object
 
 
       });
 
-      test("Changes when you click Update", async () => {
-          render(
-              <QueryClientProvider client={queryClient}>
-                  <MemoryRouter>
-                      <PersonalSchedulesEditPage />
-                  </MemoryRouter>
-              </QueryClientProvider>
-          );
-
-          await screen.findByTestId("PersonalScheduleForm-id");
-
-          const idField = screen.getByTestId("PersonalScheduleForm-id");
-          const nameField = screen.getByTestId("PersonalScheduleForm-name");
-          const descriptionField = screen.getByTestId(
-            "PersonalScheduleForm-description",
-          );
-         // const quarterField = document.querySelector(
-           // "#PersonalScheduleForm-quarter",
-          //);
-          const quarterField = screen.getByTestId("PersonalScheduleForm-quarter");
-
-          const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
-
-          expect(idField).toBeInTheDocument();
-          expect(idField).toHaveValue("1");
-          expect(nameField).toBeInTheDocument();
-          expect(nameField).toHaveValue("TestName");
-          expect(descriptionField).toBeInTheDocument();
-          expect(descriptionField).toHaveValue("TestDescription");
-          expect(quarterField).toBeInTheDocument();
-
-          fireEvent.change(nameField, { target: { value: "TestName6" } });
-          fireEvent.change(descriptionField, { target: { value: "TestDescription6" } });
-
-          fireEvent.click(submitButton);
-
-          await waitFor(() => expect(mockToast).toBeCalled());
-          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 1 name: TestName6");
-          expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
-          }); // posted object
-
+      test("renders without crashing for user", () => {
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/user/all").reply(200, []);
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <PersonalSchedulesEditPage />
+            </MemoryRouter>
+          </QueryClientProvider>,
+        );
       });
 
+      test("renders without crashing for admin", () => {
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/courses/admin/all").reply(200, []);
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <PersonalSchedulesEditPage />
+            </MemoryRouter>
+          </QueryClientProvider>,
+        );
+      });
+      const testId = "CourseTable";
+      test("renders two courses without crashing for user", async () => {
+        const queryClient = new QueryClient();
+        axiosMock
+          .onGet("/api/courses/user/psid/all?psId=1")
+          .reply(200, coursesFixtures.twoCourses);
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <PersonalSchedulesEditPage />
+            </MemoryRouter>
+          </QueryClientProvider>,
+        );
+        await waitFor(() => {
+          expect(
+            screen.getByTestId(`${testId}-cell-row-0-col-id`),
+          ).toHaveTextContent("25");
+        });
+        expect(
+          screen.getByTestId(`${testId}-cell-row-1-col-id`),
+        ).toHaveTextContent("26");
+      });
+  
+      test("cannot render course with different psid", async () => {
+        const queryClient = new QueryClient();
+        axiosMock
+          .onGet("/api/courses/user/psid/all?psId=13")
+          .reply(200, coursesFixtures.oneCourse);
+  
+        render(
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+              <PersonalSchedulesEditPage />
+            </MemoryRouter>
+          </QueryClientProvider>,
+        );
 
+        expect(
+          screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+        ).not.toBeInTheDocument();
+      });
+    });
   });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -110,9 +110,9 @@ describe("PersonalSchedulesEditPage tests", () => {
               hostedDomain: "ucsb.edu",
               admin: true,
             },
-            description: "Winter Course Plan",
+            description: "My Plan for Winter",
             quarter: "20221",
-            name: "CS154",
+            name: "Winter Courses",
           });
       });
 
@@ -144,9 +144,6 @@ describe("PersonalSchedulesEditPage tests", () => {
           const descriptionField = screen.getByTestId(
             "PersonalScheduleForm-description",
           );
-         // const quarterField = document.querySelector(
-           // "#PersonalScheduleForm-quarter",
-          //);
           const quarterField = screen.getByTestId("PersonalScheduleForm-quarter");
           const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
@@ -161,15 +158,15 @@ describe("PersonalSchedulesEditPage tests", () => {
 
           expect(quarterField).toBeInTheDocument();
 
-          expect(quarterField).toHaveValue("20221");
+          expect(quarterField).toHaveValue("W22");
           expect(submitButton).toHaveTextContent("Update");
 
-          fireEvent.change(nameField, { target: { value: "CS154" } });
-          fireEvent.change(descriptionField, { target: { value: "Winter Course Plan" } });
+          fireEvent.change(nameField, { target: { value: "Winter Courses" } });
+          fireEvent.change(descriptionField, { target: { value: "My Plan for Winter" } });
           fireEvent.click(submitButton);
 
           await waitFor(() => expect(mockToast).toBeCalled());
-          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 17 name: CS154");
+          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 17 name: Winter Courses");
 
           expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
 
@@ -190,8 +187,8 @@ describe("PersonalSchedulesEditPage tests", () => {
                 hostedDomain: "ucsb.edu",
                 admin: true,
               },
-              name: "CS154",
-              description: "Winter Course Plan",
+              name: "Winter Courses",
+              description: "My Plan for Winter",
               quarter: "20221",
           })); // posted object
 
@@ -225,7 +222,7 @@ describe("PersonalSchedulesEditPage tests", () => {
       test("renders two courses without crashing for user", async () => {
         const queryClient = new QueryClient();
         axiosMock
-          .onGet("/api/courses/user/psid/all?psId=1")
+          .onGet("/api/courses/user/psid/all?psId=17")
           .reply(200, coursesFixtures.twoCourses);
         render(
           <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -11,253 +11,270 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import mockConsole from "jest-mock-console";
 
 const mockToast = jest.fn();
-jest.mock('react-toastify', () => {
-    const originalModule = jest.requireActual('react-toastify');
-    return {
-        __esModule: true,
-        ...originalModule,
-        toast: (x) => mockToast(x)
-    };
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
 });
 
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => {
-    const originalModule = jest.requireActual('react-router-dom');
-    return {
-        __esModule: true,
-        ...originalModule,
-        useParams: () => ({
-            id: 17,
-        }),
-        Navigate: (x) => { mockNavigate(x); return null; },
-    };
+jest.mock("react-router-dom", () => {
+  const originalModule = jest.requireActual("react-router-dom");
+  return {
+    __esModule: true,
+    ...originalModule,
+    useParams: () => ({
+      id: 17,
+    }),
+    Navigate: (x) => {
+      mockNavigate(x);
+      return null;
+    },
+  };
 });
 
 describe("PersonalSchedulesEditPage tests", () => {
-
   describe("when the backend doesn't return data", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-      const axiosMock = new AxiosMockAdapter(axios);
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/personalschedules", { params: { id: 17 } })
+        .timeout();
+    });
 
-      beforeEach(() => {
-          axiosMock.reset();
-          axiosMock.resetHistory();
-          axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-          axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-          axiosMock.onGet("/api/personalschedules", { params: { id: 17 } }).timeout();
-      });
+    const queryClient = new QueryClient();
+    test("renders header but table is not present", async () => {
+      const restoreConsole = mockConsole();
 
-      const queryClient = new QueryClient();
-      test("renders header but table is not present", async () => {
-
-          const restoreConsole = mockConsole();
-
-          render(
-              <QueryClientProvider client={queryClient}>
-                  <MemoryRouter>
-                      <PersonalSchedulesEditPage />
-                  </MemoryRouter>
-              </QueryClientProvider>
-          );
-          await screen.findByText("Edit Personal Schedule");
-          expect(screen.queryByTestId("PersonalSchedule-name")).not.toBeInTheDocument();
-          restoreConsole();
-      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await screen.findByText("Edit Personal Schedule");
+      expect(
+        screen.queryByTestId("PersonalSchedule-name"),
+      ).not.toBeInTheDocument();
+      restoreConsole();
+    });
   });
 
   describe("tests where backend is working normally", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
 
-      const axiosMock = new AxiosMockAdapter(axios);
-
-      beforeEach(() => {
-          axiosMock.reset();
-          axiosMock.resetHistory();
-          axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-          axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-          axiosMock.onGet("/api/personalschedules", { params: { id: 17 } }).reply(200, {
-              id: 17,
-              user: {
-                id: 1,
-                email: "phtcon@ucsb.edu",
-                googleSub: "115856948234298493496",
-                pictureUrl:
-                  "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-                fullName: "Phill Conrad",
-                givenName: "Phill",
-                familyName: "Conrad",
-                emailVerified: true,
-                locale: "en",
-                hostedDomain: "ucsb.edu",
-                admin: true,
-              },
-              description: "My Winter Courses",
-              quarter: "20221",
-              name: "CS156",
-          });
-          axiosMock.onPut('/api/personalschedules').reply(200, {
-            id: 17,
-            user: {
-              id: 1,
-              email: "phtcon@ucsb.edu",
-              googleSub: "115856948234298493496",
-              pictureUrl:
-                "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-              fullName: "Phill Conrad",
-              givenName: "Phill",
-              familyName: "Conrad",
-              emailVerified: true,
-              locale: "en",
-              hostedDomain: "ucsb.edu",
-              admin: true,
-            },
-            description: "My Plan for Winter",
-            quarter: "20221",
-            name: "Winter Courses",
-          });
-      });
-
-      const queryClient = new QueryClient();
-      test("renders without crashing", () => {
-        axiosMock.onGet("/api/personalschedules").reply(200, []);
-          render(
-              <QueryClientProvider client={queryClient}>
-                  <MemoryRouter>
-                      <PersonalSchedulesEditPage />
-                  </MemoryRouter>
-              </QueryClientProvider>
-          );
-      });
-
-      test("Is populated with the data provided", async () => {
-          render(
-              <QueryClientProvider client={queryClient}>
-                  <MemoryRouter>
-                      <PersonalSchedulesEditPage />
-                  </MemoryRouter>
-              </QueryClientProvider>
-          );
-
-          await screen.findByTestId("PersonalScheduleForm-id");
-
-          const idField = screen.getByTestId("PersonalScheduleForm-id");
-          const nameField = screen.getByTestId("PersonalScheduleForm-name");
-          const descriptionField = screen.getByTestId(
-            "PersonalScheduleForm-description",
-          );
-          const quarterField = screen.getByTestId("PersonalScheduleForm-quarter");
-          const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
-
-          expect(idField).toBeInTheDocument();
-          expect(idField).toHaveValue("17");
-
-          expect(nameField).toBeInTheDocument();
-          expect(nameField).toHaveValue("CS156");
-
-          expect(descriptionField).toBeInTheDocument();
-          expect(descriptionField).toHaveValue("My Winter Courses");
-
-          expect(quarterField).toBeInTheDocument();
-
-          expect(quarterField).toHaveValue("W22");
-          expect(submitButton).toHaveTextContent("Update");
-
-          fireEvent.change(nameField, { target: { value: "Winter Courses" } });
-          fireEvent.change(descriptionField, { target: { value: "My Plan for Winter" } });
-          fireEvent.click(submitButton);
-
-          await waitFor(() => expect(mockToast).toBeCalled());
-          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 17 name: Winter Courses");
-
-          expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
-
-          expect(axiosMock.history.put.length).toBe(1); // times called
-          expect(axiosMock.history.put[0].params).toEqual({ id : 17 });
-          expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
-            user: {
-                id: 1,
-                email: "phtcon@ucsb.edu",
-                googleSub: "115856948234298493496",
-                pictureUrl:
-                  "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
-                fullName: "Phill Conrad",
-                givenName: "Phill",
-                familyName: "Conrad",
-                emailVerified: true,
-                locale: "en",
-                hostedDomain: "ucsb.edu",
-                admin: true,
-              },
-              name: "Winter Courses",
-              description: "My Plan for Winter",
-              quarter: "20221",
-          })); // posted object
-
-
-      });
-
-      test("renders without crashing for user", () => {
-        const queryClient = new QueryClient();
-        axiosMock.onGet("/api/courses/user/all").reply(200, []);
-        render(
-          <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-              <PersonalSchedulesEditPage />
-            </MemoryRouter>
-          </QueryClientProvider>,
-        );
-      });
-
-      test("renders without crashing for admin", () => {
-        const queryClient = new QueryClient();
-        axiosMock.onGet("/api/courses/admin/all").reply(200, []);
-        render(
-          <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-              <PersonalSchedulesEditPage />
-            </MemoryRouter>
-          </QueryClientProvider>,
-        );
-      });
-      const testId = "CourseTable";
-      test("renders two courses without crashing for user", async () => {
-        const queryClient = new QueryClient();
-        axiosMock
-          .onGet("/api/courses/user/psid/all?psId=17")
-          .reply(200, coursesFixtures.twoCourses);
-        render(
-          <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-              <PersonalSchedulesEditPage />
-            </MemoryRouter>
-          </QueryClientProvider>,
-        );
-        await waitFor(() => {
-          expect(
-            screen.getByTestId(`${testId}-cell-row-0-col-id`),
-          ).toHaveTextContent("25");
+    beforeEach(() => {
+      axiosMock.reset();
+      axiosMock.resetHistory();
+      axiosMock
+        .onGet("/api/currentUser")
+        .reply(200, apiCurrentUserFixtures.userOnly);
+      axiosMock
+        .onGet("/api/systemInfo")
+        .reply(200, systemInfoFixtures.showingNeither);
+      axiosMock
+        .onGet("/api/personalschedules", { params: { id: 17 } })
+        .reply(200, {
+          id: 17,
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          description: "My Winter Courses",
+          quarter: "20221",
+          name: "CS156",
         });
-        expect(
-          screen.getByTestId(`${testId}-cell-row-1-col-id`),
-        ).toHaveTextContent("26");
-      });
-  
-      test("cannot render course with different psid", async () => {
-        const queryClient = new QueryClient();
-        axiosMock
-          .onGet("/api/courses/user/psid/all?psId=13")
-          .reply(200, coursesFixtures.oneCourse);
-  
-        render(
-          <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-              <PersonalSchedulesEditPage />
-            </MemoryRouter>
-          </QueryClientProvider>,
-        );
-
-        expect(
-          screen.queryByTestId(`${testId}-cell-row-0-col-id`),
-        ).not.toBeInTheDocument();
+      axiosMock.onPut("/api/personalschedules").reply(200, {
+        id: 17,
+        user: {
+          id: 1,
+          email: "phtcon@ucsb.edu",
+          googleSub: "115856948234298493496",
+          pictureUrl:
+            "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+          fullName: "Phill Conrad",
+          givenName: "Phill",
+          familyName: "Conrad",
+          emailVerified: true,
+          locale: "en",
+          hostedDomain: "ucsb.edu",
+          admin: true,
+        },
+        description: "My Plan for Winter",
+        quarter: "20221",
+        name: "Winter Courses",
       });
     });
+
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
+      axiosMock.onGet("/api/personalschedules").reply(200, []);
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+
+    test("Is populated with the data provided", async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      await screen.findByTestId("PersonalScheduleForm-id");
+
+      const idField = screen.getByTestId("PersonalScheduleForm-id");
+      const nameField = screen.getByTestId("PersonalScheduleForm-name");
+      const descriptionField = screen.getByTestId(
+        "PersonalScheduleForm-description",
+      );
+      const quarterField = screen.getByTestId("PersonalScheduleForm-quarter");
+      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+      expect(idField).toBeInTheDocument();
+      expect(idField).toHaveValue("17");
+
+      expect(nameField).toBeInTheDocument();
+      expect(nameField).toHaveValue("CS156");
+
+      expect(descriptionField).toBeInTheDocument();
+      expect(descriptionField).toHaveValue("My Winter Courses");
+
+      expect(quarterField).toBeInTheDocument();
+
+      expect(quarterField).toHaveValue("W22");
+      expect(submitButton).toHaveTextContent("Update");
+
+      fireEvent.change(nameField, { target: { value: "Winter Courses" } });
+      fireEvent.change(descriptionField, {
+        target: { value: "My Plan for Winter" },
+      });
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(mockToast).toBeCalled());
+      expect(mockToast).toBeCalledWith(
+        "PersonalSchedule Updated - id: 17 name: Winter Courses",
+      );
+
+      expect(mockNavigate).toBeCalledWith({ to: "/personalschedules/list" });
+
+      expect(axiosMock.history.put.length).toBe(1); // times called
+      expect(axiosMock.history.put[0].params).toEqual({ id: 17 });
+      expect(axiosMock.history.put[0].data).toBe(
+        JSON.stringify({
+          user: {
+            id: 1,
+            email: "phtcon@ucsb.edu",
+            googleSub: "115856948234298493496",
+            pictureUrl:
+              "https://lh3.googleusercontent.com/-bQynVrzVIrU/AAAAAAAAAAI/AAAAAAAAAAA/AMZuucmkGuVsELD1ZeV5iDUAUfe6_K-p8w/s96-c/photo.jpg",
+            fullName: "Phill Conrad",
+            givenName: "Phill",
+            familyName: "Conrad",
+            emailVerified: true,
+            locale: "en",
+            hostedDomain: "ucsb.edu",
+            admin: true,
+          },
+          name: "Winter Courses",
+          description: "My Plan for Winter",
+          quarter: "20221",
+        }),
+      ); // posted object
+    });
+
+    test("renders without crashing for user", () => {
+      const queryClient = new QueryClient();
+      axiosMock.onGet("/api/courses/user/all").reply(200, []);
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+
+    test("renders without crashing for admin", () => {
+      const queryClient = new QueryClient();
+      axiosMock.onGet("/api/courses/admin/all").reply(200, []);
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+    });
+    const testId = "CourseTable";
+    test("renders two courses without crashing for user", async () => {
+      const queryClient = new QueryClient();
+      axiosMock
+        .onGet("/api/courses/user/psid/all?psId=17")
+        .reply(200, coursesFixtures.twoCourses);
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByTestId(`${testId}-cell-row-0-col-id`),
+        ).toHaveTextContent("25");
+      });
+      expect(
+        screen.getByTestId(`${testId}-cell-row-1-col-id`),
+      ).toHaveTextContent("26");
+    });
+
+    test("cannot render course with different psid", async () => {
+      const queryClient = new QueryClient();
+      axiosMock
+        .onGet("/api/courses/user/psid/all?psId=13")
+        .reply(200, coursesFixtures.oneCourse);
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        screen.queryByTestId(`${testId}-cell-row-0-col-id`),
+      ).not.toBeInTheDocument();
+    });
   });
+});

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -1,8 +1,5 @@
 
 import { fireEvent, waitFor, render, screen } from "@testing-library/react";
-
-import { render, screen } from "@testing-library/react";
-
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -72,8 +72,6 @@ describe("PersonalSchedulesEditPage tests", () => {
       ).not.toBeInTheDocument();
       restoreConsole();
     });
-
-
   });
 
   describe("tests where backend is working normally", () => {
@@ -148,7 +146,7 @@ describe("PersonalSchedulesEditPage tests", () => {
       const queryClient = new QueryClient();
       axiosMock.onGet(`/api/personalschedules?id=17`).reply(200, []);
       axiosMock.onGet(`api/personalSections/all?psId=17`).reply(200, []);
-  
+
       render(
         <QueryClientProvider client={queryClient}>
           <MemoryRouter>
@@ -156,16 +154,14 @@ describe("PersonalSchedulesEditPage tests", () => {
           </MemoryRouter>
         </QueryClientProvider>,
       );
-  
+
       const backButton = screen.getByRole("button", { name: /back/i });
       expect(backButton).toBeInTheDocument();
-  
+
       // Optional: Test button functionality
       userEvent.click(backButton);
       // Add your assertions here to ensure that clicking the button triggers the expected action.
     });
-
-
 
     test("Is populated with the data provided", async () => {
       render(

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -1,30 +1,202 @@
-import { render } from "@testing-library/react";
+import { fireEvent, waitFor, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import PersonalSchedulesEditPage from "main/pages/PersonalSchedules/PersonalSchedulesEditPage";
 
+import { coursesFixtures } from "fixtures/pscourseFixtures";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        useParams: () => ({
+            id: 1
+        }),
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("PersonalSchedulesEditPage tests", () => {
-  const axiosMock = new AxiosMockAdapter(axios);
-  axiosMock
-    .onGet("/api/currentUser")
-    .reply(200, apiCurrentUserFixtures.userOnly);
-  axiosMock
-    .onGet("/api/systemInfo")
-    .reply(200, systemInfoFixtures.showingNeither);
 
-  const queryClient = new QueryClient();
-  test("renders without crashing", () => {
-    render(
-      <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
-          <PersonalSchedulesEditPage />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
+  describe("when the backend doesn't return data", () => {
+
+      const axiosMock = new AxiosMockAdapter(axios);
+
+      beforeEach(() => {
+          axiosMock.reset();
+          axiosMock.resetHistory();
+          axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+          axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+          axiosMock.onGet("/api/personalschedules", { params: { id: 1 } }).timeout();
+      });
+
+      const queryClient = new QueryClient();
+      test("renders header but table is not present", async () => {
+
+          const restoreConsole = mockConsole();
+
+          render(
+              <QueryClientProvider client={queryClient}>
+                  <MemoryRouter>
+                      <PersonalSchedulesEditPage />
+                  </MemoryRouter>
+              </QueryClientProvider>
+          );
+          await screen.findByText("Edit Personal Schedule");
+          expect(screen.queryByTestId("PersonalSchedule-id")).not.toBeInTheDocument();
+          restoreConsole();
+      });
   });
-});
+
+  describe("tests where backend is working normally", () => {
+
+      const axiosMock = new AxiosMockAdapter(axios);
+
+      beforeEach(() => {
+          axiosMock.reset();
+          axiosMock.resetHistory();
+          axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+          axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+          axiosMock.onGet("/api/personalschedules", { params: { id: 1 } }).reply(200, {
+              id: 1,
+              name: "TestName",
+              description: "TestDescription",
+              quarter: "W08"
+          });
+          axiosMock.onPut('/api/personalschedules').reply(200, {
+              id: "6",
+              name: "TestName6",
+              description: "TestDescription6",
+              quarter: "S22"
+          });
+      });
+
+      const queryClient = new QueryClient();
+      test("renders without crashing", () => {
+          render(
+              <QueryClientProvider client={queryClient}>
+                  <MemoryRouter>
+                      <PersonalSchedulesEditPage />
+                  </MemoryRouter>
+              </QueryClientProvider>
+          );
+      });
+
+      test("Is populated with the data provided", async () => {
+
+          render(
+              <QueryClientProvider client={queryClient}>
+                  <MemoryRouter>
+                      <PersonalSchedulesEditPage />
+                  </MemoryRouter>
+              </QueryClientProvider>
+          );
+
+          await screen.findByTestId("PersonalScheduleForm-name");
+
+          const idField = screen.getByTestId("PersonalScheduleForm-id");
+          const nameField = screen.getByTestId("PersonalScheduleForm-name");
+          const descriptionField = screen.getByTestId(
+            "PersonalScheduleForm-description",
+          );
+          const quarterField = document.querySelector(
+            "#PersonalScheduleForm-quarter",
+          );
+          const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+          expect(idField).toBeInTheDocument();
+          expect(idField).toHaveValue("1");
+          expect(nameField).toBeInTheDocument();
+          expect(nameField).toHaveValue("TestName");
+          expect(descriptionField).toBeInTheDocument();
+          expect(descriptionField).toHaveValue("TestDescription");
+          expect(quarterField).toBeInTheDocument();
+
+          expect(submitButton).toHaveTextContent("Update");
+
+          fireEvent.change(idField, { target: { value: 6 } });
+          fireEvent.change(nameField, { target: { value: "TestName6" } });
+          fireEvent.change(descriptionField, { target: { value: "TestDescription6" } });
+          fireEvent.change(quarterField, { target: { value: "S22" } });
+          fireEvent.click(submitButton);
+
+          await waitFor(() => expect(mockToast).toBeCalled());
+          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 6 name: TestName6 description: TestDescription6 quarter: S22 ");
+
+          expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
+
+          expect(axiosMock.history.put.length).toBe(1); // times called
+          expect(axiosMock.history.put[0].params).toEqual({ id : 6 });
+          expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
+              id: 6,
+              name: "TestName6",
+              description: "TestDescription6",
+              quarter: "S22"
+          })); // posted object
+
+
+      });
+
+      test("Changes when you click Update", async () => {
+
+          render(
+              <QueryClientProvider client={queryClient}>
+                  <MemoryRouter>
+                      <PersonalSchedulesEditPage />
+                  </MemoryRouter>
+              </QueryClientProvider>
+          );
+
+          await screen.findByTestId("PersonalScheduleForm-name");
+
+          const idField = screen.getByTestId("PersonalScheduleForm-id");
+          const nameField = screen.getByTestId("PersonalScheduleForm-name");
+          const descriptionField = screen.getByTestId(
+            "PersonalScheduleForm-description",
+          );
+          const quarterField = document.querySelector(
+            "#PersonalScheduleForm-quarter",
+          );
+          const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+          expect(idField).toBeInTheDocument();
+          expect(idField).toHaveValue("1");
+          expect(nameField).toBeInTheDocument();
+          expect(nameField).toHaveValue("TestName");
+          expect(descriptionField).toBeInTheDocument();
+          expect(descriptionField).toHaveValue("TestDescription");
+          expect(quarterField).toBeInTheDocument();
+
+          fireEvent.change(idField, { target: { value: 6 } });
+          fireEvent.change(nameField, { target: { value: "TestName6" } });
+          fireEvent.change(descriptionField, { target: { value: "TestDescription6" } });
+          fireEvent.change(quarterField, { target: { value: "S22" } });
+
+          fireEvent.click(submitButton);
+
+          await waitFor(() => expect(mockToast).toBeCalled());
+          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 6 name: TestName6 description: TestDescription6 quarter: S22 ");
+          expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules" });
+          }); // posted object
+
+      });
+
+
+  });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -9,6 +9,7 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 import mockConsole from "jest-mock-console";
+import userEvent from "@testing-library/user-event";
 
 const mockToast = jest.fn();
 jest.mock("react-toastify", () => {
@@ -71,6 +72,8 @@ describe("PersonalSchedulesEditPage tests", () => {
       ).not.toBeInTheDocument();
       restoreConsole();
     });
+
+
   });
 
   describe("tests where backend is working normally", () => {
@@ -140,6 +143,29 @@ describe("PersonalSchedulesEditPage tests", () => {
         </QueryClientProvider>,
       );
     });
+
+    test("renders 'Back' button", () => {
+      const queryClient = new QueryClient();
+      axiosMock.onGet(`/api/personalschedules?id=17`).reply(200, []);
+      axiosMock.onGet(`api/personalSections/all?psId=17`).reply(200, []);
+  
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+  
+      const backButton = screen.getByRole("button", { name: /back/i });
+      expect(backButton).toBeInTheDocument();
+  
+      // Optional: Test button functionality
+      userEvent.click(backButton);
+      // Add your assertions here to ensure that clicking the button triggers the expected action.
+    });
+
+
 
     test("Is populated with the data provided", async () => {
       render(

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -27,9 +27,9 @@ jest.mock('react-router-dom', () => {
         __esModule: true,
         ...originalModule,
         useParams: () => ({
-            id: 1
+            id: 1,
         }),
-        Navigate: (x) => { mockNavigate(x); return null; }
+        Navigate: (x) => { mockNavigate(x); return null; },
     };
 });
 
@@ -60,7 +60,7 @@ describe("PersonalSchedulesEditPage tests", () => {
               </QueryClientProvider>
           );
           await screen.findByText("Edit Personal Schedule");
-          expect(screen.queryByTestId("PersonalSchedule-id")).not.toBeInTheDocument();
+          expect(screen.queryByTestId("PersonalSchedule-name")).not.toBeInTheDocument();
           restoreConsole();
       });
   });
@@ -81,15 +81,16 @@ describe("PersonalSchedulesEditPage tests", () => {
               quarter: "W08"
           });
           axiosMock.onPut('/api/personalschedules').reply(200, {
-              id: "6",
+              id: 1,
               name: "TestName6",
               description: "TestDescription6",
-              quarter: "S22"
+              quarter: "W08",
           });
       });
 
       const queryClient = new QueryClient();
       test("renders without crashing", () => {
+        axiosMock.onGet("/api/personalschedules").reply(200, []);
           render(
               <QueryClientProvider client={queryClient}>
                   <MemoryRouter>
@@ -100,7 +101,6 @@ describe("PersonalSchedulesEditPage tests", () => {
       });
 
       test("Is populated with the data provided", async () => {
-
           render(
               <QueryClientProvider client={queryClient}>
                   <MemoryRouter>
@@ -109,16 +109,17 @@ describe("PersonalSchedulesEditPage tests", () => {
               </QueryClientProvider>
           );
 
-          await screen.findByTestId("PersonalScheduleForm-name");
+          await screen.findByTestId("PersonalScheduleForm-id");
 
           const idField = screen.getByTestId("PersonalScheduleForm-id");
           const nameField = screen.getByTestId("PersonalScheduleForm-name");
           const descriptionField = screen.getByTestId(
             "PersonalScheduleForm-description",
           );
-          const quarterField = document.querySelector(
-            "#PersonalScheduleForm-quarter",
-          );
+         // const quarterField = document.querySelector(
+           // "#PersonalScheduleForm-quarter",
+          //);
+          const quarterField = screen.getByTestId("PersonalScheduleForm-quarter");
           const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
           expect(idField).toBeInTheDocument();
@@ -131,31 +132,28 @@ describe("PersonalSchedulesEditPage tests", () => {
 
           expect(submitButton).toHaveTextContent("Update");
 
-          fireEvent.change(idField, { target: { value: 6 } });
           fireEvent.change(nameField, { target: { value: "TestName6" } });
           fireEvent.change(descriptionField, { target: { value: "TestDescription6" } });
-          fireEvent.change(quarterField, { target: { value: "S22" } });
           fireEvent.click(submitButton);
 
           await waitFor(() => expect(mockToast).toBeCalled());
-          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 6 name: TestName6 description: TestDescription6 quarter: S22 ");
+          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 1 name: TestName6");
 
           expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
 
           expect(axiosMock.history.put.length).toBe(1); // times called
-          expect(axiosMock.history.put[0].params).toEqual({ id : 6 });
+          expect(axiosMock.history.put[0].params).toEqual({ id : 1 });
           expect(axiosMock.history.put[0].data).toBe(JSON.stringify({
-              id: 6,
+              id: 1,
               name: "TestName6",
               description: "TestDescription6",
-              quarter: "S22"
+              quarter: "W08"
           })); // posted object
 
 
       });
 
       test("Changes when you click Update", async () => {
-
           render(
               <QueryClientProvider client={queryClient}>
                   <MemoryRouter>
@@ -164,16 +162,18 @@ describe("PersonalSchedulesEditPage tests", () => {
               </QueryClientProvider>
           );
 
-          await screen.findByTestId("PersonalScheduleForm-name");
+          await screen.findByTestId("PersonalScheduleForm-id");
 
           const idField = screen.getByTestId("PersonalScheduleForm-id");
           const nameField = screen.getByTestId("PersonalScheduleForm-name");
           const descriptionField = screen.getByTestId(
             "PersonalScheduleForm-description",
           );
-          const quarterField = document.querySelector(
-            "#PersonalScheduleForm-quarter",
-          );
+         // const quarterField = document.querySelector(
+           // "#PersonalScheduleForm-quarter",
+          //);
+          const quarterField = screen.getByTestId("PersonalScheduleForm-quarter");
+
           const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
           expect(idField).toBeInTheDocument();
@@ -184,16 +184,14 @@ describe("PersonalSchedulesEditPage tests", () => {
           expect(descriptionField).toHaveValue("TestDescription");
           expect(quarterField).toBeInTheDocument();
 
-          fireEvent.change(idField, { target: { value: 6 } });
           fireEvent.change(nameField, { target: { value: "TestName6" } });
           fireEvent.change(descriptionField, { target: { value: "TestDescription6" } });
-          fireEvent.change(quarterField, { target: { value: "S22" } });
 
           fireEvent.click(submitButton);
 
           await waitFor(() => expect(mockToast).toBeCalled());
-          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 6 name: TestName6 description: TestDescription6 quarter: S22 ");
-          expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules" });
+          expect(mockToast).toBeCalledWith("PersonalSchedule Updated - id: 1 name: TestName6");
+          expect(mockNavigate).toBeCalledWith({ "to": "/personalschedules/list" });
           }); // posted object
 
       });


### PR DESCRIPTION
In this PR, we add an Edit Page for Personal Schedules and a delete function to the personal courses page containing the personal schedule's name, the course name, and the quarter, creating a much more useful and readable table for the user.

![image](https://github.com/ucsb-cs156-w24/proj-courses-w24-5pm-2/assets/119549292/d96e6314-d2c1-45ff-bec7-8f7bff10b6d9)

Closes #10 